### PR TITLE
Add a note on broken /status functionality

### DIFF
--- a/notebooks/Introduction.ipynb
+++ b/notebooks/Introduction.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,17 +50,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "40ef840c-cc9d-4591-8638-e19b821b4760\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def hello_world():\n",
     "    return \"Hello World!\"\n",
@@ -84,17 +76,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1ea423fa-a1d6-4ee1-bc6c-5e46041f0990\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tutorial_endpoint = '4b116d3c-1703-4f8f-9f6f-39921e5864df' # Public tutorial endpoint\n",
     "res = fxc.run(endpoint_id=tutorial_endpoint, function_id=func_uuid)\n",
@@ -112,20 +96,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Hello World!'"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "fxc.get_result(res)"
    ]
@@ -357,7 +330,9 @@
    "source": [
     "# Managing endpoints\n",
     "\n",
-    "funcX endpoints advertise whether or not they are online as well as information about their avaialble resources, queued tasks, and other information. If you are permitted to execute functions on an endpoint you can also retrieve the status of the endpoint. The following example shows how to look up the status (online or offline) and the number of number of waiting tasks and workers connected to the endpoint. "
+    "funcX endpoints advertise whether or not they are online as well as information about their avaialble resources, queued tasks, and other information. If you are permitted to execute functions on an endpoint you can also retrieve the status of the endpoint. The following example shows how to look up the status (online or offline) and the number of number of waiting tasks and workers connected to the endpoint. \n",
+    "\n",
+    "> **_NOTE:_**  The endpoint status functionality is broken in endpoints running `funcx-endpoint>=0.2.0,<=0.2.2`. For more info please refer [here](https://github.com/funcx-faas/funcX/issues/444)."
    ]
   },
   {
@@ -441,7 +416,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds:
Note that /status doesn't working in `endpoints>=0.2.0, <=0.2.2`.
Flushing some half executed notebook cells that were saved to git.