### PR TITLE
Updates to match executor to 1.0.5 changes

### DIFF
--- a/notebooks/Introduction.ipynb
+++ b/notebooks/Introduction.ipynb
@@ -30,30 +30,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from funcx import FuncXClient, FuncXExecutor\n",
-    "\n",
-    "fx = FuncXExecutor(FuncXClient())\n",
-    "print(\"FuncXExecutor : \", fx)"
+    "from funcx import FuncXExecutor"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# funcX 101\n",
-    "\n",
-    "The following example demonstrates how you can execute a function with the `FuncXExecutor` interface.\n",
-    "\n",
-    "\n",
-    "### Submitting a function\n",
-    "\n",
-    "To invoke a function, you must provide: \n",
-    "\n",
-    " * the function\n",
-    " * the `endpoint_id` of the endpoint on which you wish to execute that function\n",
-    " \n",
-    "Optionally, you may also specify any input arguments to the function. \n",
-    "    \n",
     "> **Note**: Here we use the public funcX tutorial endpoint. You may change the `endpoint_id` to the UUID of any endpoint for which you have permission to execute functions."
    ]
   },
@@ -72,11 +55,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "fx = FuncXExecutor(endpoint_id = tutorial_endpoint)\n",
+    "print(\"FuncXExecutor : \", fx)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# funcX 101\n",
+    "\n",
+    "The following example demonstrates how you can execute a function with the `FuncXExecutor` interface.\n",
+    "\n",
+    "\n",
+    "### Submitting a function\n",
+    "\n",
+    "To invoke a function, you must provide: \n",
+    "\n",
+    " * the function\n",
+    " \n",
+    "Optionally, you may also specify any input arguments to the function. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Define the function for remote execution\n",
     "def hello_world():\n",
     "    return \"Hello World!\"\n",
     "\n",
-    "future = fx.submit(hello_world, endpoint_id=tutorial_endpoint)\n",
+    "future = fx.submit(hello_world)\n",
     "\n",
     "print(\"Submit returned: \", future)"
    ]
@@ -134,7 +145,7 @@
     "def division_by_zero():\n",
     "    return 42 / 0 # This will raise a ZeroDivisionError\n",
     "\n",
-    "future = fx.submit(division_by_zero, endpoint_id=tutorial_endpoint)\n",
+    "future = fx.submit(division_by_zero)\n",
     "\n",
     "try:\n",
     "    future.result()\n",
@@ -164,7 +175,7 @@
     "def funcx_sum(a, b):\n",
     "    return a + b\n",
     "\n",
-    "future = fx.submit(funcx_sum, 40, 2, endpoint_id=tutorial_endpoint)\n",
+    "future = fx.submit(funcx_sum, 40, 2)\n",
     "print(f\"40 + 2 = {future.result()}\")\n"
    ]
   },
@@ -187,7 +198,7 @@
     "    from datetime import date\n",
     "    return date.today()\n",
     "\n",
-    "future = fx.submit(funcx_date, endpoint_id=tutorial_endpoint)\n",
+    "future = fx.submit(funcx_date)\n",
     "\n",
     "print(\"Date fetched from endpoint: \", future.result())"
    ]
@@ -213,7 +224,7 @@
     "    import os\n",
     "    return os.popen(\"echo Hello {} from $HOSTNAME\".format(name)).read()\n",
     "\n",
-    "future = fx.submit(funcx_echo, \"World\", endpoint_id=tutorial_endpoint)\n",
+    "future = fx.submit(funcx_echo, \"World\")\n",
     "\n",
     "print(\"Echo output: \", future.result())"
    ]
@@ -253,8 +264,7 @@
     "estimates = []\n",
     "for i in range(3):\n",
     "    estimates.append(fx.submit(pi, \n",
-    "                               10**5, \n",
-    "                               endpoint_id=tutorial_endpoint))\n",
+    "                               10**5))\n",
     "\n",
     "# get the results and calculate the total\n",
     "total = [future.result() for future in estimates]\n",
@@ -288,7 +298,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -302,7 +312,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* Moved tutorial_ep definition to the top
* Executor now only takes the endpoint_id and not the client
* submit calls do not take the endpoint_id kwarg

Please test locally if you can